### PR TITLE
Causes a validation error, and it's not necessary.

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -23,7 +23,7 @@ layout: default
     <div class="sharing-links">
       <div class="fb-share-button" data-href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}" data-layout="button_count"></div>
       <a class="twitter-share-button" href="https://twitter.com/intent/tweet">Tweet</a>
-      <script src="//platform.linkedin.com/in.js" type="text/javascript"> lang: en_US</script>
+      <script src="//platform.linkedin.com/in.js" type="text/javascript"></script>
       <script type="IN/Share"></script>
       <script src="https://apis.google.com/js/platform.js" async defer></script>
       <div class="g-plus" data-action="share" data-annotation="none" data-href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}"></div>


### PR DESCRIPTION
```
The text content of element script was not in the required format: Expected space, tab, newline, or slash but found l instead.
```