### PR TITLE
Implementing the scope of the body of the page, clears itemprop errors.

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,7 +4,7 @@ layout: compress
 <!DOCTYPE html>
 <html lang="{% if page.language %}{{ page.language }}{% elsif site.language %}{{ site.language }}{% else %}en{% endif %}">
   {% include head.html %}
-  <body>
+  <body itemscope itemtype="http://schema.org/WebPage">
     <div id="fb-root"></div>
     <script>(function(d, s, id) {
       var js, fjs = d.getElementsByTagName(s)[0];

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 ---
-<div itemscope itemtype="http://schema.org/BlogPosting" itemprop="mainEntity" class="post">
+<div class="post" itemprop="mainEntity" itemscope itemtype="http://schema.org/BlogPosting">
   <header class="post-header">
     <h1 itemprop="headline" class="post-title">{{ page.title }}</h1>
     <p class="post-meta">
@@ -10,7 +10,6 @@ layout: default
       </time>
       <meta itemprop="dateModified" content="{{ page.date | date: '%F' }}"/>
       {% if page.author %}
-        •
         <span itemprop="author" itemscope itemtype="http://schema.org/Person">
           <span itemprop="name">{{ page.author }}</span>
         </span>


### PR DESCRIPTION
<img width="1270" alt="screen shot 2017-07-26 at 10 54 41 pm" src="https://user-images.githubusercontent.com/116142/28652370-7e74e97c-7255-11e7-8750-38552b773a40.png">
